### PR TITLE
スタイルとdraggableのバグ修正

### DIFF
--- a/app/javascript/design-edit.vue
+++ b/app/javascript/design-edit.vue
@@ -44,39 +44,40 @@
           v-if="design.images && design.images.length"
           v-model="design.images"
           draggable=".item"
-          class="files grid grid-cols-3 md:grid-cols-4 gap-3">
+          :handle="'.handle'"
+          class="files grid grid-cols-3 md:grid-cols-4 gap-x-3 gap-y-4">
           <template #item="{ element }">
-            <div
-              @click="deleteImage(element)"
-              class="item relative mb-4 md:mb-8 cursor-pointer"
-              :key="element">
-              <img
-                :src="element.url"
-                alt="登録画像"
-                class="aspect-[4/3] w-full object-cover" />
-              <XMarkIcon
-                class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+            <div class="item" :key="element">
+              <div class="relative pt-[75%] cursor-pointer">
+                <img
+                  :src="element.url"
+                  alt="登録画像"
+                  class="handle absolute top-0 w-full h-full object-cover shadow-md" />
+                <XMarkIcon
+                  @click="deleteImage(element)"
+                  class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+              </div>
             </div>
           </template>
         </draggable>
         <div v-if="design.imageToDelete.length > 0">
-          <hr class="mb-2" />
+          <hr class="mt-8 mb-3" />
           <div class="text-sm flex justify-start items-center gap-1 mb-6">
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下の画像は保存されません。
           </div>
-          <div class="grid grid-cols-3 md:grid-cols-4 gap-3">
-            <div
-              @click="saveImage(image)"
-              class="relative mb-4 md:mb-8 cursor-pointer"
-              v-for="image in design.imageToDelete"
-              :key="image">
-              <img
-                :src="image.url"
-                alt="削除画像"
-                class="aspect-[4/3] w-full object-cover opacity-60" />
-              <ArrowUturnUpIcon
-                class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+          <div class="grid grid-cols-3 md:grid-cols-4 gap-x-3 gap-y-4">
+            <div v-for="image in design.imageToDelete" :key="image">
+              <div
+                @click="saveImage(image)"
+                class="relative pt-[75%] cursor-pointer">
+                <img
+                  :src="image.url"
+                  alt="削除画像"
+                  class="absolute top-0 w-full h-full object-cover opacity-60 shadow-md" />
+                <ArrowUturnUpIcon
+                  class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+              </div>
             </div>
           </div>
         </div>
@@ -95,21 +96,16 @@
         </child-text-input>
         <div
           v-if="saveYoutubeVideos.length > 0"
-          class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6 mb-4">
-          <div
-            v-for="youtubeVideo in saveYoutubeVideos"
-            :key="youtubeVideo"
-            class="relative">
+          class="grid grid-cols-2 md:grid-cols-3 gap-x-3 gap-y-4 mt-6">
+          <div v-for="youtubeVideo in saveYoutubeVideos" :key="youtubeVideo">
             <div
               @click="deleteYoutubeVideo(youtubeVideo)"
-              class="cursor-pointer">
-              <div class="w-full aspect-video pointer-events-none">
-                <YoutubeVue3
-                  :videoid="youtubeVideo.accessCode"
-                  :autoplay="0"
-                  class="w-full h-full">
-                </YoutubeVue3>
-              </div>
+              class="relative pt-[56.25%] cursor-pointer">
+              <YoutubeVue3
+                :videoid="youtubeVideo.accessCode"
+                :autoplay="0"
+                class="absolute top-0 w-full h-full shadow-md pointer-events-none">
+              </YoutubeVue3>
               <XMarkIcon
                 class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
             </div>
@@ -120,21 +116,18 @@
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下のYouTube動画は保存されません。
           </div>
-          <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-x-3 gap-y-4">
             <div
               v-for="youtubeVideo in deleteYoutubeVideos"
-              :key="youtubeVideo"
-              class="relative">
+              :key="youtubeVideo">
               <div
                 @click="saveYoutubeVideo(youtubeVideo)"
-                class="cursor-pointer">
-                <div class="w-full aspect-video pointer-events-none">
-                  <YoutubeVue3
-                    :videoid="youtubeVideo.accessCode"
-                    :autoplay="0"
-                    class="w-full h-full opacity-60">
-                  </YoutubeVue3>
-                </div>
+                class="relative pt-[56.25%] cursor-pointer">
+                <YoutubeVue3
+                  :videoid="youtubeVideo.accessCode"
+                  :autoplay="0"
+                  class="absolute top-0 w-full h-full opacity-60 shadow-md pointer-events-none">
+                </YoutubeVue3>
                 <ArrowUturnUpIcon
                   class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
               </div>
@@ -149,12 +142,12 @@
         <input-color @update-color="updateColor" />
         <div
           v-if="saveColors.length > 0"
-          class="grid grid-cols-5 sm:grid-cols-10 mt-6">
+          class="grid grid-cols-5 sm:grid-cols-10 gap-y-5 mt-6">
           <div
             v-for="color in saveColors"
             :key="color"
             :style="colorShowHexNumber(color.hexNumber)"
-            class="w-8 h-8 rounded-full shadow-md mb-4">
+            class="w-8 h-8 rounded-full shadow-md">
             <div @click="deleteColor(color)" class="relative cursor-pointer">
               <div v-if="color.lame" class="absolute w-8 h-8">
                 <div class="relative">
@@ -170,16 +163,16 @@
           </div>
         </div>
         <div v-if="deleteColors.length > 0">
-          <div class="text-sm flex justify-start items-center gap-1 my-6">
+          <div class="text-sm flex justify-start items-center gap-1 mt-6 mb-7">
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下のカラーイメージは保存されません。
           </div>
-          <div class="grid grid-cols-5 sm:grid-cols-10">
+          <div class="grid grid-cols-5 sm:grid-cols-10 gap-y-5">
             <div
               v-for="color in deleteColors"
               :key="color"
               :style="colorShowHexNumber(color.hexNumber)"
-              class="w-8 h-8 rounded-full shadow-md mb-4">
+              class="w-8 h-8 rounded-full shadow-md">
               <div @click="saveColor(color)" class="cursor-pointer">
                 <div v-if="color.lame" class="absolute w-8 h-8">
                   <div class="relative">

--- a/app/javascript/design-index.vue
+++ b/app/javascript/design-index.vue
@@ -78,7 +78,7 @@
                     ? 'open-change-actions-content'
                     : 'close-change-actions-content'
                 "
-                class="absolute -top-12 -left-14 flex justify-between gap-6 sm:gap-3 text-gray-400 cursor-pointer bg-white p-2 rounded shadow-lg">
+                class="absolute -top-12 -left-[68px] sm:-left-14 flex justify-between gap-6 sm:gap-3 text-gray-400 cursor-pointer bg-white p-2 rounded shadow-lg">
                 <design-link :id="design.id" link="edit">
                   <PencilIcon
                     @click="editDesign(design.id)"
@@ -94,7 +94,7 @@
         </div>
       </div>
     </div>
-    <div class="sticky bottom-0 py-10 bg-white/60">
+    <div class="sticky bottom-0 py-8 sm:py-10 bg-white/60">
       <design-link link="new" class="new-design-link-btn main-action-btn">
         ネイルデザインを登録
       </design-link>

--- a/app/javascript/design-new.vue
+++ b/app/javascript/design-new.vue
@@ -41,39 +41,40 @@
           v-if="design.images.length > 0"
           v-model="design.images"
           draggable=".item"
-          class="files grid grid-cols-3 md:grid-cols-4 gap-3">
+          :handle="'.handle'"
+          class="files grid grid-cols-3 md:grid-cols-4 gap-x-3 gap-y-4">
           <template #item="{ element }">
-            <div
-              @click="deleteImage(element)"
-              class="item relative mb-4 md:mb-8 cursor-pointer"
-              :key="element">
-              <img
-                :src="element"
-                alt="登録画像"
-                class="aspect-[4/3] w-full object-cover" />
-              <XMarkIcon
-                class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+            <div class="item" :key="element">
+              <div class="relative pt-[75%] cursor-pointer">
+                <img
+                  :src="element"
+                  alt="登録画像"
+                  class="handle absolute top-0 w-full h-full object-cover shadow-md" />
+                <XMarkIcon
+                  @click="deleteImage(element)"
+                  class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+              </div>
             </div>
           </template>
         </draggable>
         <div v-if="design.imageToDelete.length > 0">
-          <hr class="mb-2" />
+          <hr class="mt-8 mb-3" />
           <div class="text-sm flex justify-start items-center gap-1 mb-6">
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下の画像は保存されません。
           </div>
-          <div class="grid grid-cols-3 md:grid-cols-4 gap-3">
-            <div
-              @click="saveImage(image)"
-              class="relative mb-4 md:mb-8 cursor-pointer"
-              v-for="image in design.imageToDelete"
-              :key="image">
-              <img
-                :src="image"
-                alt="削除画像"
-                class="aspect-[4/3] w-full object-cover opacity-60" />
-              <ArrowUturnUpIcon
-                class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+          <div class="grid grid-cols-3 md:grid-cols-4 gap-x-3 gap-y-4">
+            <div v-for="image in design.imageToDelete" :key="image">
+              <div
+                @click="saveImage(image)"
+                class="relative pt-[75%] cursor-pointer">
+                <img
+                  :src="image"
+                  alt="削除画像"
+                  class="absolute top-0 w-full h-full object-cover opacity-60 shadow-md" />
+                <ArrowUturnUpIcon
+                  class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
+              </div>
             </div>
           </div>
         </div>
@@ -93,21 +94,16 @@
         </child-text-input>
         <div
           v-if="design.youtubeVideos.length > 0"
-          class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6 mb-4">
-          <div
-            v-for="youtubeVideo in design.youtubeVideos"
-            :key="youtubeVideo"
-            class="relative">
+          class="grid grid-cols-2 md:grid-cols-3 gap-x-3 gap-y-4 mt-6">
+          <div v-for="youtubeVideo in design.youtubeVideos" :key="youtubeVideo">
             <div
               @click="deleteYoutubeVideo(youtubeVideo)"
-              class="cursor-pointer">
-              <div class="w-full aspect-video pointer-events-none">
-                <YoutubeVue3
-                  :videoid="youtubeVideo.accessCode"
-                  :autoplay="0"
-                  class="w-full h-full">
-                </YoutubeVue3>
-              </div>
+              class="relative pt-[56.25%] cursor-pointer">
+              <YoutubeVue3
+                :videoid="youtubeVideo.accessCode"
+                :autoplay="0"
+                class="absolute top-0 w-full h-full shadow-md pointer-events-none">
+              </YoutubeVue3>
               <XMarkIcon
                 class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
             </div>
@@ -118,21 +114,18 @@
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下のYouTube動画は保存されません。
           </div>
-          <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-x-3 gap-y-4">
             <div
               v-for="youtubeVideo in design.youtubeVideoToDelete"
-              :key="youtubeVideo"
-              class="relative">
+              :key="youtubeVideo">
               <div
                 @click="saveYoutubeVideo(youtubeVideo)"
-                class="cursor-pointer">
-                <div class="w-full aspect-video pointer-events-none">
-                  <YoutubeVue3
-                    :videoid="youtubeVideo.accessCode"
-                    :autoplay="0"
-                    class="w-full h-full opacity-60">
-                  </YoutubeVue3>
-                </div>
+                class="relative pt-[56.25%] cursor-pointer">
+                <YoutubeVue3
+                  :videoid="youtubeVideo.accessCode"
+                  :autoplay="0"
+                  class="absolute top-0 w-full h-full opacity-60 shadow-md pointer-events-none">
+                </YoutubeVue3>
                 <ArrowUturnUpIcon
                   class="absolute right-0 top-0 -mt-2.5 -mr-2.5 select-icon" />
               </div>
@@ -147,12 +140,12 @@
         <input-color @update-color="updateColor" />
         <div
           v-if="design.colors.length > 0"
-          class="grid grid-cols-5 sm:grid-cols-10 mt-6">
+          class="grid grid-cols-5 sm:grid-cols-10 gap-y-5 mt-6">
           <div
             v-for="color in design.colors"
             :key="color"
             :style="colorShowHexNumber(color.hexNumber)"
-            class="w-8 h-8 rounded-full shadow-md mb-4">
+            class="w-8 h-8 rounded-full shadow-md">
             <div @click="deleteColor(color)" class="relative cursor-pointer">
               <div v-if="color.lame" class="absolute w-8 h-8">
                 <div class="relative">
@@ -168,16 +161,16 @@
           </div>
         </div>
         <div v-if="design.colorToDelete.length > 0">
-          <div class="text-sm flex justify-start items-center gap-1 my-6">
+          <div class="text-sm flex justify-start items-center gap-1 mt-6 mb-7">
             <ExclamationTriangleIcon class="w-6 h-6" />
             以下のカラーイメージは保存されません。
           </div>
-          <div class="grid grid-cols-5 sm:grid-cols-10">
+          <div class="grid grid-cols-5 sm:grid-cols-10 gap-y-5">
             <div
               v-for="color in design.colorToDelete"
               :key="color"
               :style="colorShowHexNumber(color.hexNumber)"
-              class="w-8 h-8 rounded-full shadow-md mb-4">
+              class="w-8 h-8 rounded-full shadow-md">
               <div @click="saveColor(color)" class="relative cursor-pointer">
                 <div v-if="color.lame" class="absolute w-8 h-8">
                   <div class="relative">

--- a/app/javascript/design-show.vue
+++ b/app/javascript/design-show.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="design-title page-content-title">{{ design.title }}</h1>
-    <div class="grid gap-y-12 sm:gap-y-10">
+    <div class="grid gap-y-14 sm:gap-y-10">
       <div
         class="design-nailpart w-20 h-10 flex justify-center items-center rounded mx-auto bg-gray-800 text-white">
         {{ design.nailPart }}
@@ -9,25 +9,25 @@
       <div class="design-images">
         <h2 class="text-lg mb-2">画像</h2>
         <div
-          class="text-sm ml-0.5 mb-2 sm:mb-6"
+          class="text-sm ml-0.5 sm:mb-6"
           v-if="!design.images || !design.images.length">
           登録されている画像はありません。
         </div>
         <div v-else>
-          <div class="text-sm mb-2 flex justify-start items-center gap-1">
+          <div class="text-sm mb-4 flex justify-start items-center gap-1">
             <InformationCircleIcon class="w-6 h-6" />
             画像をクリックすると拡大できます。
           </div>
-          <div class="grid grid-cols-3 gap-1 md:grid-cols-4">
+          <div class="grid grid-cols-3 md:grid-cols-4 gap-1.5">
             <div
-              class="drop-shadow-lg mb-2 md:mb-8"
+              class="relative pt-[75%] shadow-lg"
               v-for="(image, index) in design.images"
               :key="index"
               @click="showImages(index)">
               <img
                 :src="image"
                 alt="登録画像"
-                class="mt-2 aspect-[4/3] w-full object-cover" />
+                class="absolute top-0 w-full h-full object-cover" />
             </div>
           </div>
           <vue-easy-lightbox
@@ -41,12 +41,12 @@
       <div class="design-youtubevideos">
         <h2 class="text-lg mb-2">YouTube動画</h2>
         <div
-          class="text-sm ml-0.5 mb-2 sm:mb-6"
+          class="text-sm ml-0.5 sm:mb-6"
           v-if="design.youtubeVideos.length === 0">
           登録されているYouTube動画はありません。
         </div>
         <div v-else>
-          <div class="text-sm mb-2">
+          <div class="text-sm mb-4">
             <h3 class="flex justify-start items-center gap-1">
               <InformationCircleIcon class="w-6 h-6" />
               動画の再生方法
@@ -57,17 +57,16 @@
               アプリもしくはWEBブラウザに移動します。
             </p>
           </div>
-          <div class="grid grid-cols-2 md:grid-cols-3 gap-1">
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-1.5">
             <div
               v-for="youtubeVideo in design.youtubeVideos"
-              :key="youtubeVideo.id"
-              class="drop-shadow-lg mb-2 md:mb-8">
+              :key="youtubeVideo.id">
               <div class="hidden">{{ youtubeVideo.accessCode }}</div>
-              <div class="w-full aspect-video">
+              <div class="relative pt-[56.25%] w-full shadow-lg">
                 <YoutubeVue3
                   :videoid="youtubeVideo.accessCode"
                   :autoplay="0"
-                  class="mt-2 w-full h-full youtubevideo-accesscode">
+                  class="absolute top-0 w-full h-full youtubevideo-accesscode">
                 </YoutubeVue3>
               </div>
             </div>
@@ -76,18 +75,16 @@
       </div>
       <div class="design-colors">
         <h2 class="text-lg mb-2">カラー</h2>
-        <div
-          class="text-sm ml-0.5 mb-2 sm:mb-6"
-          v-if="design.colors.length === 0">
+        <div class="text-sm ml-0.5 sm:mb-6" v-if="design.colors.length === 0">
           登録されているカラーはありません。
         </div>
         <div v-else>
-          <div class="grid grid-cols-6 md:grid-cols-12">
+          <div class="grid grid-cols-6 md:grid-cols-12 gap-y-2.5">
             <div
               v-for="color in design.colors"
               :key="color.id"
               :style="colorShowHexNumber(color.hexNumber)"
-              class="w-8 h-8 rounded-full drop-shadow-lg mb-2 md:mb-8">
+              class="w-8 h-8 rounded-full shadow-md">
               <div class="hidden">{{ color.lame }}</div>
               <div class="hidden">{{ color.hexNumber }}</div>
               <div v-if="color.lame" class="relative">
@@ -103,9 +100,7 @@
       </div>
       <div class="design-parts">
         <h2 class="text-lg mb-2">パーツ</h2>
-        <div
-          class="text-sm ml-0.5 mb-2 sm:mb-6"
-          v-if="design.parts.length === 0">
+        <div class="text-sm ml-0.5 sm:mb-6" v-if="design.parts.length === 0">
           登録されているパーツはありません。
         </div>
         <div v-else class="mb-2 sm:mb-8">
@@ -139,7 +134,7 @@
       <div class="design-description">
         <h2 class="text-lg mb-2">調べた内容・メモ</h2>
         <div
-          class="text-sm ml-0.5 mb-2 sm:mb-6"
+          class="text-sm ml-0.5 sm:mb-6"
           v-if="design.description.length === 0">
           登録されているメモはありません。
         </div>
@@ -168,7 +163,7 @@
         </div>
       </div>
     </div>
-    <design-link :id="design.id" link="edit" class="main-action-btn my-2"
+    <design-link :id="design.id" link="edit" class="main-action-btn mb-2"
       >ネイルデザインを編集</design-link
     >
     <delete-design :id="design.id" class="text-btn mb-8"

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -25,7 +25,7 @@
     @apply block w-8 h-4 cursor-pointer bg-gray-300 rounded-full border border-gray-300 box-content after:block after:h-4 after:w-4 after:rounded-full after:bg-white after:transition peer-checked:bg-gray-600 peer-checked:after:translate-x-full;
   }
   .arrow-icon {
-    @apply sm:text-lg relative text-center before:content-[''] before:absolute before:top-2/4 before:right-6 before:h-px before:w-8 before:bg-white hover:before:right-3 hover:before:w-12 before:ease-in before:delay-300 before:transition-all after:absolute after:top-5 after:right-6 hover:after:right-3 after:h-2.5 after:w-2.5 after:rotate-45 after:border-t after:border-r after:border-white after:content-[''] after:ease-in after:delay-300 after:transition-all;
+    @apply sm:text-lg relative text-center before:content-[''] before:absolute before:top-1/2 before:right-6 before:h-px before:w-8 before:bg-white hover:before:right-3 hover:before:w-12 before:ease-in before:delay-300 before:transition-all after:absolute after:bottom-4 after:right-6 hover:after:right-3 after:rotate-45 after:h-2.5 after:w-2.5 after:border-t after:border-r after:border-white after:content-[''] after:ease-in after:delay-300 after:transition-all;
   }
   .required-icon {
     @apply block relative after:absolute after:content-['必須'] after:text-white after:text-xs after:bg-orange-500 after:py-1.5 after:px-2 after:rounded after:ml-1;

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,6 +1,6 @@
 .flex
-  = link_to image_tag('logo.svg'), user_signed_in? ? designs_path : root_path, class: 'block m-2 w-12', alt: 'ネイリエ'
-  #nav-toggle.absolute.z-40.top-0.right-0.mt-5.mr-3.md:hidden
+  = link_to image_tag('logo.svg'), user_signed_in? ? designs_path : root_path, class: 'block m-2 w-11 md:w-12', alt: 'ネイリエ'
+  #nav-toggle.absolute.z-40.top-0.right-0.mt-4.mr-2.md:hidden
     .w-7
       span.absolute.top-0.w-full.h-px.block.bg-gray-500.ease-out.duration-500
       span.absolute.top-3.w-full.h-px.block.bg-gray-500

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -3,9 +3,9 @@
 
 = javascript_pack_tag 'top'
 .text-center
-  .relative.aspect-square.w-2/3.sm:w-1/4.mx-auto
-    = image_tag 'drawing.svg', class: 'w-full h-full m-auto drop-shadow-md fade-up', alt: 'ネイルアートの絵画'
-    = image_tag 'brush.svg', class: 'w-full h-full absolute top-11 left-0 -right-16 m-auto drop-shadow-md fade-in', alt: '筆'
+  .relative.w-1/2.sm:w-1/5.mx-auto
+    = image_tag 'drawing.svg', class: 'w-full h-full drop-shadow-md fade-up', alt: 'ネイルアートの絵画'
+    = image_tag 'brush.svg', class: 'w-full h-full absolute top-12 -right-9 sm:top-14 sm:-right-10 drop-shadow-md fade-in', alt: '筆'
   h1.fade-up.mb-10
     span.block.text-sm.sm:text-base.mt-8.mb-4
       | ネイリストのためのデザインメモ

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -45,10 +45,10 @@
       = image_tag 'color-registration.gif', class: 'block w-48 sm:w-60 mx-auto shadow-md mt-4 mb-8 sm:mb-0', alt: 'カラーイメージ登録機能'
     .scroll-fade-in
       | 簡単検索でデータ管理しやすい
-      = image_tag 'search.gif', class: 'block w-48 sm:w-60 mx-auto drop-shadow-md mt-4 mb-4 sm:mb-0', alt: 'タグ検索機能'
+      = image_tag 'search.gif', class: 'block w-48 sm:w-60 mx-auto shadow-md mt-4 mb-4 sm:mb-0', alt: 'タグ検索機能'
   h2.mt-16.mb-8.text-lg.sm:mt-20.sm:mb-14.sm:text-xl
     | 検定用としても使える
-  = image_tag 'exam.svg', class: 'block w-28 sm:w-36 mx-auto drop-shadow-md mb-6 scroll-fade-in', alt: '検定対策'
+  = image_tag 'exam.svg', class: 'block w-28 sm:w-36 mx-auto drop-shadow-lg mb-6 scroll-fade-in', alt: '検定対策'
   .text-sm.leading-6.sm:text-base.sm:leading-8
     | 講習で撮った画像や動画・利用する
     br.sm:hidden


### PR DESCRIPTION
取り急ぎわかってる範囲内で以下修正

- Safariでaspect-ratioがどのページも効いていなかったので書き方を変更

- drop-shadowが効かないので四角の画像はbox-shadowに変更
(それ以外の画像はちょっとした見た目の違いになるので取り急ぎそのまま)
  
- draggableの設定箇所がclickイベントが反応する時としない時があるので、optionでD&Dを制御
(特にAndroid。タッチパネルの感度かと思ったが違った)
参考 [Vue\.Draggableをスマホで使う時](https://crieit.net/posts/Vue-Draggable)
